### PR TITLE
Improve type inference

### DIFF
--- a/.changeset/six-mugs-kiss.md
+++ b/.changeset/six-mugs-kiss.md
@@ -1,0 +1,5 @@
+---
+"preact-multi-provider": minor
+---
+
+Improve TypeScript types so that correct context values are automatically inferred. This means the `provide()` helper function isn't needed anymore.

--- a/README.md
+++ b/README.md
@@ -31,44 +31,10 @@ const BoofContexxt = createContext("boof");
 // usage
 <MultiProvider
   values={[
-    provide(FooContext, "foo value"),
-    provide(BarContext, "bar value"),
-    provide(BazContext, "baz value"),
-    provide(BoofContext, "boof value"),
-  ]}
-></MultiProvider>;
-```
-
-## TypeScript usage
-
-The snippet below works perfectly fine for TypeScript. But if you want to ensure that the provided value matches the context value we need to help TS out a little, because it doesn't support [existential generics](https://github.com/microsoft/TypeScript/issues/14466).
-
-```jsx
-import { createContext } from "preact";
-import { MultiProvider } from "preact-multi-provider";
-
-const StringContext = createContext("foo");
-
-<MultiProvider
-  values={[
-    // Bad: TS allows invalid value here
-    { context: StringContext, value: 2 },
-  ]}
-></MultiProvider>;
-```
-
-With our helper
-
-```jsx
-import { createContext } from "preact";
-import { MultiProvider, provide } from "preact-multi-provider";
-
-const StringContext = createContext("foo");
-
-<MultiProvider
-  values={[
-    // Good: TS errors when value doesn't match context
-    provide(StringContext, "foo"),
+    { context: FooContext, value: "foo value" },
+    { context: BarContext, value: "bar value" },
+    { context: BazContext, value: "baz value" },
+    { context: BoofContext, value: "boof value" },
   ]}
 ></MultiProvider>;
 ```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,23 +1,22 @@
-import {
-  type Component,
-  type ComponentChildren,
-  type FunctionComponent,
-  type Context,
-} from "preact";
+import { type Component, type ComponentChildren, type Context } from "preact";
 
 export type ContextDef<T> = {
   context: Context<T>;
   value: T;
 };
 
-export interface MultiProviderProps {
-  values: ContextDef<any>[];
+export interface MultiProviderProps<
+  T extends readonly [unknown, ...unknown[]]
+> {
+  values: {
+    [K in keyof T]: ContextDef<T[K]>;
+  };
   children: ComponentChildren;
 }
 
-function _MultiProvider(
-  this: Component<MultiProviderProps>,
-  props: MultiProviderProps
+export function MultiProvider<T extends readonly [unknown, ...unknown[]]>(
+  this: Component<MultiProviderProps<T>>,
+  props: MultiProviderProps<T>
 ) {
   if (!this.getChildContext) {
     let subs: Component[][] = [];
@@ -43,7 +42,7 @@ function _MultiProvider(
 
     this.getChildContext = () => ctx;
 
-    this.shouldComponentUpdate = function (_props: MultiProviderProps) {
+    this.shouldComponentUpdate = function (_props: MultiProviderProps<T>) {
       const current = this.props.values;
       const next = _props.values;
       for (let i = 0; i < next.length; i++) {
@@ -62,9 +61,10 @@ function _MultiProvider(
   return props.children as any;
 }
 
-export const MultiProvider =
-  _MultiProvider as FunctionComponent<MultiProviderProps>;
-
+/**
+ * @deprecated - This is not needed anymore. It was a helper to guide
+ * TypeScript inference, but with recent improvements to our typings this is redundant.
+ */
 export function provide<T>(context: Context<T>, value: T): ContextDef<T> {
   return { context, value };
 }


### PR DESCRIPTION
With the amazing improvements suggested in #8 by @thetarnav TypeScript is able to infer the correct values. There is no need for the `provide` helper function anymore. Thanks a gain to @thetarnav for the tip. This is fantastic and feels much more natural!

Fixes #8